### PR TITLE
Build with GHC-9.8: no more head, tail, init, last (x-partial warning)

### DIFF
--- a/src/full/Agda/Termination/TypeBased/Definitions.hs
+++ b/src/full/Agda/Termination/TypeBased/Definitions.hs
@@ -59,6 +59,7 @@ import qualified Agda.Termination.Order as Order
 import Data.List (unfoldr)
 import qualified Agda.Benchmarking as Benchmark
 import Agda.TypeChecking.Monad.Benchmark (billTo)
+import qualified Agda.Utils.List1 as List1
 
 
 -- | 'initSizeTypeEncoding names' computes size types for every definition in 'names'
@@ -377,8 +378,8 @@ encodeDatatypeDomain :: Bool -> Bool -> [Bool] -> Tele (Dom Type) -> SizeType
 encodeDatatypeDomain isRecursive _ params EmptyTel =
   let size = if isRecursive then SDefined 0 else SUndefined
       -- tail because scanl inserts the given starting element in the beginning
-      treeArgs = tail $
-        scanl (\(ind, t) isGeneric -> if isGeneric then (ind + 1, SizeGenericVar 0 ind) else (ind, UndefinedSizeType))
+      treeArgs = List1.tail $ List1.scanl
+              (\(ind, t) isGeneric -> if isGeneric then (ind + 1, SizeGenericVar 0 ind) else (ind, UndefinedSizeType))
               (0, UndefinedSizeType)
               params
       actualArgs = reverse (map snd treeArgs)


### PR DESCRIPTION
Use of `head` and `tail` etc. is strongly discouraged in the Agda code base, and GHC 9.8 does not let it through any more (we have `-Werror`).

This PR mostly does the naive thing to get rid of these functions in terms of `...WithDefault __IMPOSSIBLE__` variants.  I guess in some situations one could make more use of `List1` to not even have the possibility of an empty list.
See also:
- https://github.com/agda/agda/pull/7079